### PR TITLE
Do not expose internal functions in parseArgs export

### DIFF
--- a/src/js/internal/util/parse_args/index.js
+++ b/src/js/internal/util/parse_args/index.js
@@ -397,20 +397,8 @@ To specify an option argument starting with a dash use ${example}.`;
       return result;
     };
 
-    exports.parseArgs = Object.assign(parseArgs, {
-      // needed by tests
-      internal: {
-        isLoneLongOption,
-        isLoneShortOption,
-        isLongOptionAndValue,
-        isOptionValue,
-        isOptionLikeValue,
-        isShortOptionAndValue,
-        isShortOptionGroup,
-        findLongOptionForShort,
-      },
-    });
-  },
+    exports.parseArgs = parseArgs;
+  }
 });
 
 export default requireParseArgs();

--- a/src/js/internal/util/parse_args/internal/validators.js
+++ b/src/js/internal/util/parse_args/internal/validators.js
@@ -14,11 +14,11 @@ const requireValidators = __commonJS({
     // Every addition or modification to this file must be evaluated
     // during the PR review.
 
-    const { ArrayIsArray, ArrayPrototypeIncludes, ArrayPrototypeJoin } = require("./primordials");
+    const { ArrayIsArray, ArrayPrototypeIncludes, ArrayPrototypeJoin } = require("./primordials").default;
 
     const {
       codes: { ERR_INVALID_ARG_TYPE },
-    } = require("./errors");
+    } = require("./errors").default;
 
     function validateString(value, name) {
       if (typeof value !== "string") {

--- a/src/js/internal/util/parse_args/utils.js
+++ b/src/js/internal/util/parse_args/utils.js
@@ -16,9 +16,9 @@ const requireUtils = __commonJS({
       StringPrototypeCharAt,
       StringPrototypeIncludes,
       StringPrototypeStartsWith,
-    } = require("./internal/primordials");
+    } = require("./internal/primordials").default;
 
-    const { validateObject } = require("./internal/validators");
+    const { validateObject } = require("./internal/validators").default;
 
     // These are internal utilities to make the parsing logic easier to read, and
     // add lots of detail for the curious. They are in a separate file to allow

--- a/test/js/node/util/parse_args/find-long-option-for-short.test.js
+++ b/test/js/node/util/parse_args/find-long-option-for-short.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const findLongOptionForShort = parseArgs.internal.findLongOptionForShort;
+const { findLongOptionForShort } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("findLongOptionForShort: when passed empty options then returns short", () => {
   expect(findLongOptionForShort("a", {})).toEqual("a");

--- a/test/js/node/util/parse_args/is-lone-long-option.test.js
+++ b/test/js/node/util/parse_args/is-lone-long-option.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isLoneLongOption = parseArgs.internal.isLoneLongOption;
+const { isLoneLongOption } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("isLoneLongOption: when passed short option then returns false", () => {
   expect(isLoneLongOption("-s")).toBeFalse();

--- a/test/js/node/util/parse_args/is-lone-short-option.test.js
+++ b/test/js/node/util/parse_args/is-lone-short-option.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isLoneShortOption = parseArgs.internal.isLoneShortOption;
+const { isLoneShortOption } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("isLoneShortOption: when passed short option then returns true", () => {
   expect(isLoneShortOption("-s")).toBeTrue();

--- a/test/js/node/util/parse_args/is-long-option-and-value.test.js
+++ b/test/js/node/util/parse_args/is-long-option-and-value.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isLongOptionAndValue = parseArgs.internal.isLongOptionAndValue;
+const { isLongOptionAndValue } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("isLongOptionAndValue: when passed short option then returns false", () => {
   expect(isLongOptionAndValue("-s")).toBeFalse();

--- a/test/js/node/util/parse_args/is-option-like-value.test.js
+++ b/test/js/node/util/parse_args/is-option-like-value.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isOptionLikeValue = parseArgs.internal.isOptionLikeValue;
+const { isOptionLikeValue } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 // Basically rejecting values starting with a dash, but run through the interesting possibilities.
 

--- a/test/js/node/util/parse_args/is-option-value.test.js
+++ b/test/js/node/util/parse_args/is-option-value.test.js
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 import { parseArgs } from "node:util";
-const isOptionValue = parseArgs.internal.isOptionValue;
+const { isOptionValue } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 // Options are greedy so simple behaviour, but run through the interesting possibilities.
 

--- a/test/js/node/util/parse_args/is-short-option-and-value.test.js
+++ b/test/js/node/util/parse_args/is-short-option-and-value.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isShortOptionAndValue = parseArgs.internal.isShortOptionAndValue;
+const { isShortOptionAndValue } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("isShortOptionAndValue: when passed lone short option then returns false", () => {
   expect(isShortOptionAndValue("-s", {})).toBeFalse();

--- a/test/js/node/util/parse_args/is-short-option-group.test.js
+++ b/test/js/node/util/parse_args/is-short-option-group.test.js
@@ -1,6 +1,5 @@
 import { test, expect } from "bun:test";
-import { parseArgs } from "node:util";
-const isShortOptionGroup = parseArgs.internal.isShortOptionGroup;
+const { isShortOptionGroup } = require("../../../../../src/js/internal/util/parse_args/utils").default;
 
 test("isShortOptionGroup: when passed lone short option then returns false", () => {
   expect(isShortOptionGroup("-s", {})).toBeFalse();


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
